### PR TITLE
Added C14 prices #15

### DIFF
--- a/index.html
+++ b/index.html
@@ -163,6 +163,51 @@
             <td><a href="https://www.backblaze.com/b2/cloud-storage.html">1</a></td>
         </tr>
         <tr>
+            <td>C14 Intensive Service Level</td>
+            <td>0.5 €c</td>
+            <td>0</td>
+            <td>0</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>99.999999999%</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><a href="https://www.online.net/en/c14">1</a>. </td>
+        </tr>
+        <tr>
+            <td>C14 Standard Service Level</td>
+            <td>0.2 €c</td>
+            <td>0-1.0 €c(ops cost)</td>
+            <td>0-1.0 €c(ops cost)</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>99.999999999%</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><a href="https://www.online.net/en/c14">1</a>. </td>
+        </tr>
+        <tr>
+            <td>C14 Enterprise Service Level</td>
+            <td>0.4 €c</td>
+            <td>0-2.5 €c(ops cost)</td>
+            <td>0-2.5 €c(ops cost)</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td>99.99999999972%</td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td></td>
+            <td><a href="https://www.online.net/en/c14">1</a>. </td>
+        </tr>
+        <tr>
             <td>DreamHost DreamObjects</td>
             <td>2.5</td>
             <td>5.0</td>


### PR DESCRIPTION
C14 has a peculiar setup where bandwidth is free, but you pay for operations *in GB* to/from a scratch storage area called your "safe-deposit box".

Since it's not possible to access data without going through the "safe-deposit box", I've put this up as bandwidth costs.  However, since it is possible to remove data from the "safe-deposit box" and not pass it on to storage, it is possible to pay less than the operations cost, therefore the range is 0-1.0 for example, and not 1.0.

The prices are in EUR.  Not sure how to write euro cents, but I've used €c.